### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ Download the module however you like.  I'd recommend pulling it down with Git by
 
     mkdir ~/src
     cd    ~/src
-    git clone git@github.com:kkung/nginx-static-etags.git ./nginx-static-stags
+    git clone https://github.com/kkung/nginx-static-etags.git ./nginx-static-stags
 
 To use the module, you'll have to compile it into Nginx.  So, download the Nginx source, configure it with the module path, and compile:
 


### PR DESCRIPTION
Changed the protocol from SSH to HTTPS, so that anyone can clone the repository, no matter if they have SSH set up with github or not.
